### PR TITLE
[MVP][PR2] Discover/validate CLI + deterministic artifact + examples/docs

### DIFF
--- a/cmd/bering/main.go
+++ b/cmd/bering/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"os"
+
+	"github.com/MB3R-Lab/Bering/internal/app"
+)
+
+func main() {
+	runner := app.NewRunner(os.Stdout, os.Stderr)
+	os.Exit(runner.Run(os.Args[1:]))
+}

--- a/configs/replicas.sample.yaml
+++ b/configs/replicas.sample.yaml
@@ -1,0 +1,6 @@
+replicas:
+  frontend: 2
+  checkout: 3
+  payment: 2
+  inventory: 2
+

--- a/docs/mvp-scope-and-limits.md
+++ b/docs/mvp-scope-and-limits.md
@@ -1,0 +1,31 @@
+# MVP Scope and Limits
+
+## In scope
+
+- Discover model from trace files/directories.
+- Emit Sheaft-compatible `bering-model.json` (v1.0.0 contract).
+- Validate artifact with strict `metadata.schema` match.
+- Deterministic output ordering and canonical JSON serialization.
+
+## Out of scope (MVP)
+
+- Non-trace connectors (runtime service registries, topology APIs).
+- Advanced dependency semantics (timeouts, retries, circuit breakers).
+- Correlated failures and probabilistic calibration from production data.
+- Multi-version schema negotiation.
+
+## Confidence heuristic (MVP)
+
+`metadata.confidence` is deterministic and computed from discovery coverage:
+
+- base score: `0.35`
+- `+0.20` if more than one service discovered
+- `+0.15` if at least one edge discovered
+- `+0.15` if at least one endpoint inferred
+- `+min(0.15, cross_service_parent_child_ratio * 0.15)`
+
+Result is clamped to `[0,1]` and rounded to 2 decimals.
+
+This score is informational in MVP and should not be interpreted as a calibrated
+probability of correctness.
+

--- a/docs/trace-input-format.md
+++ b/docs/trace-input-format.md
@@ -1,0 +1,67 @@
+# Trace Input Format (MVP)
+
+Bering MVP supports two JSON input formats.
+
+## 1) Normalized spans JSON
+
+Top-level shape:
+
+```json
+{
+  "spans": [
+    {
+      "trace_id": "trace-1",
+      "span_id": "span-1",
+      "parent_span_id": "",
+      "service": "frontend",
+      "kind": "server",
+      "name": "GET /checkout",
+      "attributes": {
+        "http.request.method": "GET",
+        "http.route": "/checkout"
+      }
+    }
+  ]
+}
+```
+
+Accepted aliases:
+
+- `traceId` for `trace_id`
+- `spanId` for `span_id`
+- `parentSpanId` for `parent_span_id`
+- `service_name` or `service.name` for `service`
+
+## 2) Raw OTel JSON payload
+
+Expected hierarchy:
+
+- `resourceSpans[]`
+- `resourceSpans[].resource.attributes[]`
+- `resourceSpans[].scopeSpans[]` (or `instrumentationLibrarySpans[]`)
+- `...scopeSpans[].spans[]`
+
+Supported OTel fields:
+
+- `traceId`, `spanId`, `parentSpanId`, `name`, `kind`
+- resource/span attributes in key/value form (`key` + `value.stringValue|intValue|doubleValue|boolValue`)
+
+`service.name` is resolved from resource attributes first, then span attributes.
+
+## Discovery-relevant attributes
+
+- HTTP endpoint inference:
+  - `http.request.method`, `http.method`
+  - `http.route`, `url.path`, `http.target`
+- Async edge heuristic:
+  - `messaging.system`
+  - `messaging.destination`
+  - `messaging.operation`
+  - span kind `producer` or `consumer`
+
+## Input mode
+
+- `--input` can point to:
+  - a single JSON file
+  - a directory (all `*.json` files recursively, sorted by path)
+

--- a/examples/outputs/bering-model.normalized.sample.json
+++ b/examples/outputs/bering-model.normalized.sample.json
@@ -1,0 +1,73 @@
+{
+  "edges": [
+    {
+      "blocking": true,
+      "from": "checkout",
+      "kind": "sync",
+      "to": "inventory"
+    },
+    {
+      "blocking": false,
+      "from": "checkout",
+      "kind": "async",
+      "to": "payment"
+    },
+    {
+      "blocking": true,
+      "from": "frontend",
+      "kind": "sync",
+      "to": "checkout"
+    }
+  ],
+  "endpoints": [
+    {
+      "entry_service": "checkout",
+      "id": "checkout:POST /process",
+      "success_predicate_ref": "checkout:POST /process"
+    },
+    {
+      "entry_service": "frontend",
+      "id": "frontend:GET /checkout",
+      "success_predicate_ref": "frontend:GET /checkout"
+    },
+    {
+      "entry_service": "frontend",
+      "id": "frontend:GET /health",
+      "success_predicate_ref": "frontend:GET /health"
+    }
+  ],
+  "metadata": {
+    "confidence": 0.94,
+    "discovered_at": "2026-03-03T00:00:00Z",
+    "schema": {
+      "digest": "sha256:7dc733936a9d3f94ab92f46a30d4c8d0f5c05d60670c4247786c59a3fe7630f7",
+      "name": "io.mb3r.bering.model",
+      "uri": "https://schemas.mb3r.dev/bering/model/v1.0.0/model.schema.json",
+      "version": "1.0.0"
+    },
+    "source_ref": "bering://discover?input=examples%2Ftraces%2Fnormalized.sample.json",
+    "source_type": "bering"
+  },
+  "services": [
+    {
+      "id": "checkout",
+      "name": "checkout",
+      "replicas": 1
+    },
+    {
+      "id": "frontend",
+      "name": "frontend",
+      "replicas": 1
+    },
+    {
+      "id": "inventory",
+      "name": "inventory",
+      "replicas": 1
+    },
+    {
+      "id": "payment",
+      "name": "payment",
+      "replicas": 1
+    }
+  ]
+}

--- a/examples/outputs/bering-model.otel.sample.json
+++ b/examples/outputs/bering-model.otel.sample.json
@@ -1,0 +1,73 @@
+{
+  "edges": [
+    {
+      "blocking": true,
+      "from": "checkout",
+      "kind": "sync",
+      "to": "inventory"
+    },
+    {
+      "blocking": false,
+      "from": "checkout",
+      "kind": "async",
+      "to": "payment"
+    },
+    {
+      "blocking": true,
+      "from": "frontend",
+      "kind": "sync",
+      "to": "checkout"
+    }
+  ],
+  "endpoints": [
+    {
+      "entry_service": "checkout",
+      "id": "checkout:POST /process",
+      "success_predicate_ref": "checkout:POST /process"
+    },
+    {
+      "entry_service": "frontend",
+      "id": "frontend:GET /checkout",
+      "success_predicate_ref": "frontend:GET /checkout"
+    },
+    {
+      "entry_service": "frontend",
+      "id": "frontend:GET /health",
+      "success_predicate_ref": "frontend:GET /health"
+    }
+  ],
+  "metadata": {
+    "confidence": 0.94,
+    "discovered_at": "2026-03-03T00:00:00Z",
+    "schema": {
+      "digest": "sha256:7dc733936a9d3f94ab92f46a30d4c8d0f5c05d60670c4247786c59a3fe7630f7",
+      "name": "io.mb3r.bering.model",
+      "uri": "https://schemas.mb3r.dev/bering/model/v1.0.0/model.schema.json",
+      "version": "1.0.0"
+    },
+    "source_ref": "bering://discover?input=examples%2Ftraces%2Fotel.sample.json",
+    "source_type": "bering"
+  },
+  "services": [
+    {
+      "id": "checkout",
+      "name": "checkout",
+      "replicas": 1
+    },
+    {
+      "id": "frontend",
+      "name": "frontend",
+      "replicas": 1
+    },
+    {
+      "id": "inventory",
+      "name": "inventory",
+      "replicas": 1
+    },
+    {
+      "id": "payment",
+      "name": "payment",
+      "replicas": 1
+    }
+  ]
+}

--- a/examples/traces/normalized.sample.json
+++ b/examples/traces/normalized.sample.json
@@ -1,0 +1,59 @@
+{
+  "spans": [
+    {
+      "trace_id": "t-checkout",
+      "span_id": "frontend-1",
+      "service": "frontend",
+      "kind": "server",
+      "name": "GET /checkout",
+      "attributes": {
+        "http.request.method": "GET",
+        "http.route": "/checkout"
+      }
+    },
+    {
+      "trace_id": "t-checkout",
+      "span_id": "checkout-1",
+      "parent_span_id": "frontend-1",
+      "service": "checkout",
+      "kind": "server",
+      "name": "POST /process",
+      "attributes": {
+        "http.request.method": "POST",
+        "http.route": "/process"
+      }
+    },
+    {
+      "trace_id": "t-checkout",
+      "span_id": "payment-1",
+      "parent_span_id": "checkout-1",
+      "service": "payment",
+      "kind": "consumer",
+      "name": "kafka consume payment-events",
+      "attributes": {
+        "messaging.system": "kafka",
+        "messaging.destination": "payment-events"
+      }
+    },
+    {
+      "trace_id": "t-checkout",
+      "span_id": "inventory-1",
+      "parent_span_id": "checkout-1",
+      "service": "inventory",
+      "kind": "client",
+      "name": "reserve inventory"
+    },
+    {
+      "trace_id": "t-health",
+      "span_id": "frontend-2",
+      "service": "frontend",
+      "kind": "server",
+      "name": "GET /health",
+      "attributes": {
+        "http.request.method": "GET",
+        "http.route": "/health"
+      }
+    }
+  ]
+}
+

--- a/examples/traces/otel.sample.json
+++ b/examples/traces/otel.sample.json
@@ -1,0 +1,167 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "frontend"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "trace-1",
+              "spanId": "span-frontend-1",
+              "name": "GET /checkout",
+              "kind": 2,
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/checkout"
+                  }
+                }
+              ]
+            },
+            {
+              "traceId": "trace-2",
+              "spanId": "span-frontend-2",
+              "name": "GET /health",
+              "kind": 2,
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/health"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "checkout"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "trace-1",
+              "spanId": "span-checkout-1",
+              "parentSpanId": "span-frontend-1",
+              "name": "POST /process",
+              "kind": 2,
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "POST"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/process"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "payment"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "trace-1",
+              "spanId": "span-payment-1",
+              "parentSpanId": "span-checkout-1",
+              "name": "publish payment-events",
+              "kind": 4,
+              "attributes": [
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": "payment-events"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "inventory"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "trace-1",
+              "spanId": "span-inventory-1",
+              "parentSpanId": "span-checkout-1",
+              "name": "reserve inventory",
+              "kind": 3,
+              "attributes": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,0 +1,183 @@
+package app
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/MB3R-Lab/Bering/internal/connectors/traces"
+	"github.com/MB3R-Lab/Bering/internal/discovery"
+	"github.com/MB3R-Lab/Bering/internal/model"
+	"github.com/MB3R-Lab/Bering/internal/schema"
+)
+
+const (
+	ExitOK    = 0
+	ExitError = 1
+)
+
+type Runner struct {
+	stdout io.Writer
+	stderr io.Writer
+	now    func() time.Time
+}
+
+func NewRunner(stdout, stderr io.Writer) Runner {
+	return Runner{
+		stdout: stdout,
+		stderr: stderr,
+		now:    time.Now,
+	}
+}
+
+func (r Runner) Run(args []string) int {
+	if len(args) == 0 {
+		r.printUsage()
+		return ExitError
+	}
+
+	switch args[0] {
+	case "discover":
+		return r.runDiscover(args[1:])
+	case "validate":
+		return r.runValidate(args[1:])
+	case "help", "--help", "-h":
+		r.printUsage()
+		return ExitOK
+	default:
+		r.printfErr("unknown command: %s\n\n", args[0])
+		r.printUsage()
+		return ExitError
+	}
+}
+
+func (r Runner) runDiscover(args []string) int {
+	fs := flag.NewFlagSet("discover", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	input := fs.String("input", "", "Path to trace input file or directory")
+	out := fs.String("out", "bering-model.json", "Path to output model JSON")
+	replicas := fs.String("replicas", "", "Path to replicas override file (yaml or json)")
+	discoveredAt := fs.String("discovered-at", "", "RFC3339 timestamp override for metadata.discovered_at")
+
+	if err := fs.Parse(args); err != nil {
+		r.printfErr("discover flag parse error: %v\n", err)
+		return ExitError
+	}
+	if strings.TrimSpace(*input) == "" {
+		r.printfErr("discover requires --input\n")
+		return ExitError
+	}
+
+	discoveredAtValue := strings.TrimSpace(*discoveredAt)
+	if discoveredAtValue == "" {
+		discoveredAtValue = r.now().UTC().Format(time.RFC3339)
+	}
+	if _, err := time.Parse(time.RFC3339, discoveredAtValue); err != nil {
+		r.printfErr("invalid --discovered-at value (expected RFC3339): %v\n", err)
+		return ExitError
+	}
+
+	spans, err := traces.Load(*input)
+	if err != nil {
+		r.printfErr("load traces: %v\n", err)
+		return ExitError
+	}
+
+	override := map[string]int{}
+	if strings.TrimSpace(*replicas) != "" {
+		override, err = traces.LoadReplicasOverride(*replicas)
+		if err != nil {
+			r.printfErr("load replicas override: %v\n", err)
+			return ExitError
+		}
+	}
+
+	mdl, err := discovery.Build(spans, discovery.Options{
+		SourceRef:        discovery.BuildSourceRef(*input),
+		DiscoveredAt:     discoveredAtValue,
+		ReplicasOverride: override,
+	})
+	if err != nil {
+		r.printfErr("discover model: %v\n", err)
+		return ExitError
+	}
+
+	raw, err := model.MarshalCanonical(mdl)
+	if err != nil {
+		r.printfErr("serialize model: %v\n", err)
+		return ExitError
+	}
+
+	if err := schema.ValidateJSON(raw); err != nil {
+		r.printfErr("post-discovery model validation failed: %v\n", err)
+		return ExitError
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*out), 0o755); err != nil {
+		r.printfErr("create output directory: %v\n", err)
+		return ExitError
+	}
+	if err := os.WriteFile(*out, raw, 0o644); err != nil {
+		r.printfErr("write output model: %v\n", err)
+		return ExitError
+	}
+
+	r.printf("model written: %s\n", *out)
+	r.printf("services=%d edges=%d endpoints=%d confidence=%.2f\n", len(mdl.Services), len(mdl.Edges), len(mdl.Endpoints), mdl.Metadata.Confidence)
+	return ExitOK
+}
+
+func (r Runner) runValidate(args []string) int {
+	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	input := fs.String("input", "", "Path to Bering model JSON")
+
+	if err := fs.Parse(args); err != nil {
+		r.printfErr("validate flag parse error: %v\n", err)
+		return ExitError
+	}
+	if strings.TrimSpace(*input) == "" {
+		r.printfErr("validate requires --input\n")
+		return ExitError
+	}
+
+	raw, err := os.ReadFile(*input)
+	if err != nil {
+		r.printfErr("read model file: %v\n", err)
+		return ExitError
+	}
+
+	if err := schema.ValidateJSON(raw); err != nil {
+		r.printfErr("contract validation failed: %v\n", err)
+		return ExitError
+	}
+	if _, err := model.ParseJSON(raw); err != nil {
+		r.printfErr("semantic validation failed: %v\n", err)
+		return ExitError
+	}
+
+	r.printf("model is valid: %s\n", *input)
+	return ExitOK
+}
+
+func (r Runner) printUsage() {
+	fmt.Fprintln(r.stdout, "Bering CLI")
+	fmt.Fprintln(r.stdout)
+	fmt.Fprintln(r.stdout, "Usage:")
+	fmt.Fprintln(r.stdout, "  bering discover --input <trace-file|dir> [--out bering-model.json] [--replicas replicas.yaml|json] [--discovered-at RFC3339]")
+	fmt.Fprintln(r.stdout, "  bering validate --input <bering-model.json>")
+}
+
+func (r Runner) printf(format string, args ...any) {
+	fmt.Fprintf(r.stdout, format, args...)
+}
+
+func (r Runner) printfErr(format string, args ...any) {
+	fmt.Fprintf(r.stderr, format, args...)
+}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,118 @@
+package app
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestDiscoverAndValidate_NormalizedFixture(t *testing.T) {
+	root := repoRoot(t)
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir root: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(prevWD)
+	}()
+
+	input := filepath.Join("examples", "traces", "normalized.sample.json")
+	expected := filepath.Join(root, "examples", "outputs", "bering-model.normalized.sample.json")
+	out := filepath.Join(t.TempDir(), "bering-model.json")
+
+	var stdout, stderr bytes.Buffer
+	runner := NewRunner(&stdout, &stderr)
+
+	exitCode := runner.Run([]string{
+		"discover",
+		"--input", input,
+		"--out", out,
+		"--discovered-at", "2026-03-03T00:00:00Z",
+	})
+	if exitCode != ExitOK {
+		t.Fatalf("discover failed (exit=%d): stderr=%s", exitCode, stderr.String())
+	}
+
+	actualRaw, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read discovered output: %v", err)
+	}
+	expectedRaw, err := os.ReadFile(expected)
+	if err != nil {
+		t.Fatalf("read expected output: %v", err)
+	}
+	if !bytes.Equal(actualRaw, expectedRaw) {
+		t.Fatalf("discover output mismatch\nactual:\n%s\nexpected:\n%s", actualRaw, expectedRaw)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runner.Run([]string{"validate", "--input", out})
+	if exitCode != ExitOK {
+		t.Fatalf("validate failed (exit=%d): stderr=%s", exitCode, stderr.String())
+	}
+}
+
+func TestDiscoverAndValidate_OTLPFixture(t *testing.T) {
+	root := repoRoot(t)
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir root: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(prevWD)
+	}()
+
+	input := filepath.Join("examples", "traces", "otel.sample.json")
+	expected := filepath.Join(root, "examples", "outputs", "bering-model.otel.sample.json")
+	out := filepath.Join(t.TempDir(), "bering-model.json")
+
+	var stdout, stderr bytes.Buffer
+	runner := NewRunner(&stdout, &stderr)
+
+	exitCode := runner.Run([]string{
+		"discover",
+		"--input", input,
+		"--out", out,
+		"--discovered-at", "2026-03-03T00:00:00Z",
+	})
+	if exitCode != ExitOK {
+		t.Fatalf("discover failed (exit=%d): stderr=%s", exitCode, stderr.String())
+	}
+
+	actualRaw, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read discovered output: %v", err)
+	}
+	expectedRaw, err := os.ReadFile(expected)
+	if err != nil {
+		t.Fatalf("read expected output: %v", err)
+	}
+	if !bytes.Equal(actualRaw, expectedRaw) {
+		t.Fatalf("discover output mismatch\nactual:\n%s\nexpected:\n%s", actualRaw, expectedRaw)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runner.Run([]string{"validate", "--input", out})
+	if exitCode != ExitOK {
+		t.Fatalf("validate failed (exit=%d): stderr=%s", exitCode, stderr.String())
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+}

--- a/internal/connectors/traces/loader.go
+++ b/internal/connectors/traces/loader.go
@@ -1,0 +1,395 @@
+package traces
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Span struct {
+	TraceID      string
+	SpanID       string
+	ParentSpanID string
+	Service      string
+	Name         string
+	Kind         string
+	Attributes   map[string]any
+}
+
+func Load(inputPath string) ([]Span, error) {
+	paths, err := collectInputFiles(inputPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no trace json files found at %q", inputPath)
+	}
+
+	out := make([]Span, 0, len(paths)*8)
+	for _, path := range paths {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read trace input %q: %w", path, err)
+		}
+		spans, err := parseTracePayload(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parse trace input %q: %w", path, err)
+		}
+		out = append(out, spans...)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("discovered zero spans from %q", inputPath)
+	}
+	return out, nil
+}
+
+func LoadReplicasOverride(path string) (map[string]int, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read replicas override file: %w", err)
+	}
+
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".json":
+		return parseReplicasJSON(raw)
+	case ".yaml", ".yml":
+		return parseReplicasYAML(raw)
+	default:
+		// Attempt JSON first, then YAML for extension-less files.
+		if replicas, err := parseReplicasJSON(raw); err == nil {
+			return replicas, nil
+		}
+		return parseReplicasYAML(raw)
+	}
+}
+
+func collectInputFiles(inputPath string) ([]string, error) {
+	info, err := os.Stat(inputPath)
+	if err != nil {
+		return nil, fmt.Errorf("stat input path: %w", err)
+	}
+	if !info.IsDir() {
+		return []string{inputPath}, nil
+	}
+
+	files := []string{}
+	err = filepath.WalkDir(inputPath, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.EqualFold(filepath.Ext(path), ".json") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk input directory: %w", err)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func parseTracePayload(raw []byte) ([]Span, error) {
+	doc, err := decodeAnyJSON(raw)
+	if err != nil {
+		return nil, err
+	}
+	if spans, ok := parseNormalized(doc); ok {
+		return spans, nil
+	}
+	if spans, ok := parseOTLP(doc); ok {
+		return spans, nil
+	}
+	return nil, fmt.Errorf("unsupported trace format: expected normalized {\"spans\": [...]} or OTel resourceSpans payload")
+}
+
+func parseNormalized(doc any) ([]Span, bool) {
+	root, ok := doc.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+
+	rawSpans, ok := root["spans"].([]any)
+	if !ok {
+		return nil, false
+	}
+
+	out := make([]Span, 0, len(rawSpans))
+	for _, rawSpan := range rawSpans {
+		obj, ok := rawSpan.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		attrs := map[string]any{}
+		if rawAttrs, ok := obj["attributes"]; ok {
+			attrs = toMap(rawAttrs)
+		}
+		mergeNonEmpty(attrs, "http.request.method", firstNonEmptyString(obj["http.request.method"], obj["http.method"], obj["method"]))
+		mergeNonEmpty(attrs, "http.route", firstNonEmptyString(obj["http.route"], obj["route"]))
+		mergeNonEmpty(attrs, "http.target", firstNonEmptyString(obj["http.target"], obj["target"]))
+		mergeNonEmpty(attrs, "url.path", firstNonEmptyString(obj["url.path"], obj["path"]))
+		mergeNonEmpty(attrs, "messaging.system", firstNonEmptyString(obj["messaging.system"]))
+
+		out = append(out, Span{
+			TraceID:      firstNonEmptyString(obj["trace_id"], obj["traceId"]),
+			SpanID:       firstNonEmptyString(obj["span_id"], obj["spanId"]),
+			ParentSpanID: firstNonEmptyString(obj["parent_span_id"], obj["parentSpanId"]),
+			Service:      firstNonEmptyString(obj["service"], obj["service_name"], obj["service.name"]),
+			Name:         firstNonEmptyString(obj["name"]),
+			Kind:         strings.ToLower(strings.TrimSpace(firstNonEmptyString(obj["kind"]))),
+			Attributes:   attrs,
+		})
+	}
+	return out, true
+}
+
+func parseOTLP(doc any) ([]Span, bool) {
+	root, ok := doc.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+
+	resourceSpans, ok := root["resourceSpans"].([]any)
+	if !ok {
+		return nil, false
+	}
+
+	out := []Span{}
+	for _, rawResourceSpan := range resourceSpans {
+		resourceSpan, ok := rawResourceSpan.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		resourceAttrs := attributeMap(nil)
+		if resourceObj, ok := resourceSpan["resource"].(map[string]any); ok {
+			resourceAttrs = attributeMap(resourceObj["attributes"])
+		}
+
+		rawScopeSpans := firstNonNil(resourceSpan["scopeSpans"], resourceSpan["instrumentationLibrarySpans"])
+		scopeSpans, ok := rawScopeSpans.([]any)
+		if !ok {
+			continue
+		}
+
+		for _, rawScopeSpan := range scopeSpans {
+			scopeSpan, ok := rawScopeSpan.(map[string]any)
+			if !ok {
+				continue
+			}
+			rawSpans, ok := scopeSpan["spans"].([]any)
+			if !ok {
+				continue
+			}
+
+			for _, rawSpan := range rawSpans {
+				spanObj, ok := rawSpan.(map[string]any)
+				if !ok {
+					continue
+				}
+				attrs := attributeMap(spanObj["attributes"])
+
+				mergedAttrs := map[string]any{}
+				for k, v := range resourceAttrs {
+					mergedAttrs[k] = v
+				}
+				for k, v := range attrs {
+					mergedAttrs[k] = v
+				}
+
+				service := strings.TrimSpace(firstNonEmptyString(
+					mergedAttrs["service.name"],
+					spanObj["service"],
+				))
+				kind := mapSpanKind(firstNonEmptyString(spanObj["kind"]))
+
+				out = append(out, Span{
+					TraceID:      firstNonEmptyString(spanObj["traceId"], spanObj["trace_id"]),
+					SpanID:       firstNonEmptyString(spanObj["spanId"], spanObj["span_id"]),
+					ParentSpanID: firstNonEmptyString(spanObj["parentSpanId"], spanObj["parent_span_id"]),
+					Service:      service,
+					Name:         firstNonEmptyString(spanObj["name"]),
+					Kind:         kind,
+					Attributes:   mergedAttrs,
+				})
+			}
+		}
+	}
+	return out, true
+}
+
+func parseReplicasJSON(raw []byte) (map[string]int, error) {
+	wrapper := struct {
+		Replicas map[string]int `json:"replicas"`
+	}{}
+	if err := json.Unmarshal(raw, &wrapper); err == nil && len(wrapper.Replicas) > 0 {
+		return validateReplicas(wrapper.Replicas)
+	}
+
+	direct := map[string]int{}
+	if err := json.Unmarshal(raw, &direct); err != nil {
+		return nil, fmt.Errorf("decode replicas json: %w", err)
+	}
+	return validateReplicas(direct)
+}
+
+func parseReplicasYAML(raw []byte) (map[string]int, error) {
+	wrapper := struct {
+		Replicas map[string]int `yaml:"replicas"`
+	}{}
+	if err := yaml.Unmarshal(raw, &wrapper); err == nil && len(wrapper.Replicas) > 0 {
+		return validateReplicas(wrapper.Replicas)
+	}
+
+	direct := map[string]int{}
+	if err := yaml.Unmarshal(raw, &direct); err != nil {
+		return nil, fmt.Errorf("decode replicas yaml: %w", err)
+	}
+	return validateReplicas(direct)
+}
+
+func validateReplicas(values map[string]int) (map[string]int, error) {
+	out := make(map[string]int, len(values))
+	for key, value := range values {
+		id := strings.TrimSpace(key)
+		if id == "" {
+			return nil, fmt.Errorf("replicas override contains empty service id")
+		}
+		if value < 0 {
+			return nil, fmt.Errorf("replicas override for %q must be >= 0", id)
+		}
+		out[id] = value
+	}
+	return out, nil
+}
+
+func decodeAnyJSON(raw []byte) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var out any
+	if err := dec.Decode(&out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func attributeMap(raw any) map[string]any {
+	switch typed := raw.(type) {
+	case map[string]any:
+		return typed
+	case []any:
+		out := map[string]any{}
+		for _, entry := range typed {
+			obj, ok := entry.(map[string]any)
+			if !ok {
+				continue
+			}
+			key := firstNonEmptyString(obj["key"])
+			if key == "" {
+				continue
+			}
+			if value, ok := obj["value"]; ok {
+				out[key] = otelValue(value)
+			}
+		}
+		return out
+	default:
+		return map[string]any{}
+	}
+}
+
+func otelValue(v any) any {
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return v
+	}
+	for _, key := range []string{"stringValue", "intValue", "doubleValue", "boolValue", "value"} {
+		if value, exists := obj[key]; exists {
+			return otelValue(value)
+		}
+	}
+	return v
+}
+
+func mapSpanKind(rawKind string) string {
+	rawKind = strings.TrimSpace(strings.ToLower(rawKind))
+	switch rawKind {
+	case "2", "server":
+		return "server"
+	case "3", "client":
+		return "client"
+	case "4", "producer":
+		return "producer"
+	case "5", "consumer":
+		return "consumer"
+	case "1", "internal", "":
+		return "internal"
+	default:
+		// Preserve textual kind values if they are already meaningful.
+		if _, err := strconv.Atoi(rawKind); err == nil {
+			return "internal"
+		}
+		return rawKind
+	}
+}
+
+func toMap(v any) map[string]any {
+	switch typed := v.(type) {
+	case map[string]any:
+		return typed
+	default:
+		return map[string]any{}
+	}
+}
+
+func mergeNonEmpty(dst map[string]any, key, value string) {
+	if strings.TrimSpace(value) == "" {
+		return
+	}
+	if _, exists := dst[key]; exists {
+		return
+	}
+	dst[key] = value
+}
+
+func firstNonNil(values ...any) any {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
+}
+
+func firstNonEmptyString(values ...any) string {
+	for _, value := range values {
+		switch typed := value.(type) {
+		case string:
+			if strings.TrimSpace(typed) != "" {
+				return strings.TrimSpace(typed)
+			}
+		case json.Number:
+			if typed.String() != "" {
+				return typed.String()
+			}
+		case float64:
+			return strconv.FormatFloat(typed, 'f', -1, 64)
+		case int:
+			return strconv.Itoa(typed)
+		}
+	}
+	return ""
+}

--- a/internal/connectors/traces/loader_test.go
+++ b/internal/connectors/traces/loader_test.go
@@ -1,0 +1,122 @@
+package traces
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad_Normalized(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trace.json")
+	raw := `{
+  "spans": [
+    {
+      "trace_id": "t1",
+      "span_id": "s1",
+      "service": "frontend",
+      "kind": "server",
+      "name": "GET /checkout",
+      "attributes": {
+        "http.request.method": "GET",
+        "http.route": "/checkout"
+      }
+    }
+  ]
+}`
+	if err := os.WriteFile(path, []byte(raw), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	spans, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := len(spans), 1; got != want {
+		t.Fatalf("span count mismatch: got=%d want=%d", got, want)
+	}
+	if got := spans[0].Service; got != "frontend" {
+		t.Fatalf("service mismatch: got=%s", got)
+	}
+}
+
+func TestLoad_OTLP(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trace.json")
+	raw := `{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "service.name", "value": { "stringValue": "frontend" } }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "abc",
+              "spanId": "def",
+              "name": "GET /health",
+              "kind": 2,
+              "attributes": [
+                { "key": "http.request.method", "value": { "stringValue": "GET" } },
+                { "key": "http.route", "value": { "stringValue": "/health" } }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}`
+	if err := os.WriteFile(path, []byte(raw), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	spans, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got, want := len(spans), 1; got != want {
+		t.Fatalf("span count mismatch: got=%d want=%d", got, want)
+	}
+	if got := spans[0].Kind; got != "server" {
+		t.Fatalf("kind mismatch: got=%s", got)
+	}
+}
+
+func TestLoadReplicasOverride(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "replicas.json")
+	yamlPath := filepath.Join(dir, "replicas.yaml")
+
+	if err := os.WriteFile(jsonPath, []byte(`{"frontend":2,"checkout":3}`), 0o644); err != nil {
+		t.Fatalf("write json fixture: %v", err)
+	}
+	if err := os.WriteFile(yamlPath, []byte("replicas:\n  frontend: 2\n  checkout: 3\n"), 0o644); err != nil {
+		t.Fatalf("write yaml fixture: %v", err)
+	}
+
+	fromJSON, err := LoadReplicasOverride(jsonPath)
+	if err != nil {
+		t.Fatalf("LoadReplicasOverride(json) error: %v", err)
+	}
+	if fromJSON["frontend"] != 2 || fromJSON["checkout"] != 3 {
+		t.Fatalf("unexpected json replicas: %+v", fromJSON)
+	}
+
+	fromYAML, err := LoadReplicasOverride(yamlPath)
+	if err != nil {
+		t.Fatalf("LoadReplicasOverride(yaml) error: %v", err)
+	}
+	if fromYAML["frontend"] != 2 || fromYAML["checkout"] != 3 {
+		t.Fatalf("unexpected yaml replicas: %+v", fromYAML)
+	}
+}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -1,0 +1,343 @@
+package discovery
+
+import (
+	"fmt"
+	"math"
+	"net/url"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/MB3R-Lab/Bering/internal/connectors/traces"
+	"github.com/MB3R-Lab/Bering/internal/model"
+	"github.com/MB3R-Lab/Bering/internal/schema"
+)
+
+const SourceTypeBering = "bering"
+
+type Options struct {
+	SourceRef        string
+	DiscoveredAt     string
+	ReplicasOverride map[string]int
+}
+
+func Build(spans []traces.Span, opts Options) (model.ResilienceModel, error) {
+	if len(spans) == 0 {
+		return model.ResilienceModel{}, fmt.Errorf("no spans provided for discovery")
+	}
+
+	discoveredAt := opts.DiscoveredAt
+	if strings.TrimSpace(discoveredAt) == "" {
+		discoveredAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	if _, err := time.Parse(time.RFC3339, discoveredAt); err != nil {
+		return model.ResilienceModel{}, fmt.Errorf("discovered_at must be RFC3339: %w", err)
+	}
+
+	sourceRef := strings.TrimSpace(opts.SourceRef)
+	if sourceRef == "" {
+		sourceRef = "bering://discover"
+	}
+
+	spanByKey := map[string]traces.Span{}
+	serviceSet := map[string]int{}
+	for _, span := range spans {
+		service := strings.TrimSpace(span.Service)
+		if service == "" {
+			continue
+		}
+		if _, exists := serviceSet[service]; !exists {
+			serviceSet[service] = 1
+		}
+		if span.TraceID != "" && span.SpanID != "" {
+			spanByKey[traceSpanKey(span.TraceID, span.SpanID)] = span
+		}
+	}
+
+	if len(serviceSet) == 0 {
+		return model.ResilienceModel{}, fmt.Errorf("discovery produced no services")
+	}
+
+	for serviceID, replicas := range opts.ReplicasOverride {
+		if _, exists := serviceSet[serviceID]; !exists {
+			return model.ResilienceModel{}, fmt.Errorf("replicas override references unknown service %q", serviceID)
+		}
+		serviceSet[serviceID] = replicas
+	}
+
+	edgeSet := map[string]model.Edge{}
+	endpointSet := map[string]model.Endpoint{}
+	linkedCrossServiceEdges := 0
+
+	for _, span := range spans {
+		if strings.TrimSpace(span.Service) == "" {
+			continue
+		}
+
+		parent, hasParent := parentSpan(span, spanByKey)
+		if hasParent && strings.TrimSpace(parent.Service) != "" && parent.Service != span.Service {
+			kind := edgeKind(parent, span)
+			blocking := kind == model.EdgeKindSync
+			key := edgeKey(parent.Service, span.Service, kind, blocking)
+			if _, exists := edgeSet[key]; !exists {
+				edgeSet[key] = model.Edge{
+					From:     parent.Service,
+					To:       span.Service,
+					Kind:     kind,
+					Blocking: blocking,
+				}
+			}
+			linkedCrossServiceEdges++
+		}
+
+		if endpoint, ok := inferEndpoint(span, parent, hasParent); ok {
+			endpointSet[endpoint.ID] = endpoint
+		}
+	}
+
+	services := make([]model.Service, 0, len(serviceSet))
+	for id, replicas := range serviceSet {
+		services = append(services, model.Service{
+			ID:       id,
+			Name:     id,
+			Replicas: replicas,
+		})
+	}
+	sort.Slice(services, func(i, j int) bool { return services[i].ID < services[j].ID })
+
+	edges := make([]model.Edge, 0, len(edgeSet))
+	for _, edge := range edgeSet {
+		edges = append(edges, edge)
+	}
+	sort.Slice(edges, func(i, j int) bool {
+		left, right := edges[i], edges[j]
+		if left.From != right.From {
+			return left.From < right.From
+		}
+		if left.To != right.To {
+			return left.To < right.To
+		}
+		if left.Kind != right.Kind {
+			return left.Kind < right.Kind
+		}
+		return !left.Blocking && right.Blocking
+	})
+
+	endpoints := make([]model.Endpoint, 0, len(endpointSet))
+	for _, endpoint := range endpointSet {
+		endpoints = append(endpoints, endpoint)
+	}
+	sort.Slice(endpoints, func(i, j int) bool { return endpoints[i].ID < endpoints[j].ID })
+
+	confidence := calculateConfidence(len(spans), len(services), len(edges), len(endpoints), linkedCrossServiceEdges)
+	mdl := model.ResilienceModel{
+		Services:  services,
+		Edges:     edges,
+		Endpoints: endpoints,
+		Metadata: model.Metadata{
+			SourceType:   SourceTypeBering,
+			SourceRef:    sourceRef,
+			DiscoveredAt: discoveredAt,
+			Confidence:   confidence,
+			Schema: model.SchemaRef{
+				Name:    schema.ExpectedSchemaName,
+				Version: schema.ExpectedSchemaVersion,
+				URI:     schema.ExpectedSchemaURI,
+				Digest:  schema.ExpectedSchemaDigest,
+			},
+		},
+	}
+	if err := mdl.ValidateSemantic(); err != nil {
+		return model.ResilienceModel{}, err
+	}
+	mdl.SortDeterministic()
+	return mdl, nil
+}
+
+func BuildSourceRef(input string) string {
+	clean := strings.TrimSpace(input)
+	if clean == "" {
+		return "bering://discover"
+	}
+	clean = filepath.ToSlash(filepath.Clean(clean))
+	return "bering://discover?input=" + url.QueryEscape(clean)
+}
+
+func parentSpan(child traces.Span, index map[string]traces.Span) (traces.Span, bool) {
+	if strings.TrimSpace(child.TraceID) == "" || strings.TrimSpace(child.ParentSpanID) == "" {
+		return traces.Span{}, false
+	}
+	parent, ok := index[traceSpanKey(child.TraceID, child.ParentSpanID)]
+	return parent, ok
+}
+
+func traceSpanKey(traceID, spanID string) string {
+	return strings.TrimSpace(traceID) + "|" + strings.TrimSpace(spanID)
+}
+
+func edgeKind(parent, child traces.Span) model.EdgeKind {
+	if isAsyncSpan(parent) || isAsyncSpan(child) {
+		return model.EdgeKindAsync
+	}
+	return model.EdgeKindSync
+}
+
+func isAsyncSpan(span traces.Span) bool {
+	kind := strings.ToLower(strings.TrimSpace(span.Kind))
+	if kind == "producer" || kind == "consumer" {
+		return true
+	}
+	if attrString(span.Attributes, "messaging.system") != "" {
+		return true
+	}
+	if attrString(span.Attributes, "messaging.destination") != "" {
+		return true
+	}
+	if attrString(span.Attributes, "messaging.operation") != "" {
+		return true
+	}
+	return false
+}
+
+func inferEndpoint(span, parent traces.Span, hasParent bool) (model.Endpoint, bool) {
+	if strings.TrimSpace(span.Service) == "" {
+		return model.Endpoint{}, false
+	}
+
+	method := strings.ToUpper(strings.TrimSpace(firstAttr(
+		span.Attributes,
+		"http.request.method",
+		"http.method",
+	)))
+	if method == "" {
+		method, _ = parseMethodAndPathFromSpanName(span.Name)
+	}
+	if method == "" {
+		return model.Endpoint{}, false
+	}
+
+	path := strings.TrimSpace(firstAttr(
+		span.Attributes,
+		"http.route",
+		"url.path",
+		"http.target",
+	))
+	if path == "" {
+		_, path = parseMethodAndPathFromSpanName(span.Name)
+	}
+	path = normalizePath(path)
+	if path == "" {
+		return model.Endpoint{}, false
+	}
+
+	isServer := strings.EqualFold(span.Kind, "server")
+	if !isServer {
+		// If span isn't marked as server, only keep it as entry when it has no same-service parent.
+		if hasParent && parent.Service == span.Service {
+			return model.Endpoint{}, false
+		}
+	}
+
+	id := fmt.Sprintf("%s:%s %s", span.Service, method, path)
+	return model.Endpoint{
+		ID:                  id,
+		EntryService:        span.Service,
+		SuccessPredicateRef: id,
+	}, true
+}
+
+func calculateConfidence(totalSpans, serviceCount, edgeCount, endpointCount, linkedCrossEdges int) float64 {
+	score := 0.35
+	if serviceCount > 1 {
+		score += 0.2
+	}
+	if edgeCount > 0 {
+		score += 0.15
+	}
+	if endpointCount > 0 {
+		score += 0.15
+	}
+	if totalSpans > 0 && linkedCrossEdges > 0 {
+		score += math.Min(0.15, (float64(linkedCrossEdges)/float64(totalSpans))*0.15)
+	}
+	if score > 1 {
+		score = 1
+	}
+	// Keep two decimals stable for deterministic output readability.
+	return math.Round(score*100) / 100
+}
+
+func edgeKey(from, to string, kind model.EdgeKind, blocking bool) string {
+	return fmt.Sprintf("%s|%s|%s|%t", from, to, kind, blocking)
+}
+
+func firstAttr(attrs map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value := attrString(attrs, key); strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func attrString(attrs map[string]any, key string) string {
+	if attrs == nil {
+		return ""
+	}
+	value, ok := attrs[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		return fmt.Sprintf("%v", typed)
+	}
+}
+
+func parseMethodAndPathFromSpanName(name string) (string, string) {
+	parts := strings.Fields(strings.TrimSpace(name))
+	if len(parts) < 2 {
+		return "", ""
+	}
+	method := strings.ToUpper(parts[0])
+	if !isHTTPMethod(method) {
+		return "", ""
+	}
+	return method, parts[1]
+}
+
+func isHTTPMethod(method string) bool {
+	switch method {
+	case "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if idx := strings.Index(path, "?"); idx >= 0 {
+		path = path[:idx]
+	}
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		if parsed, err := url.Parse(path); err == nil {
+			path = parsed.Path
+		}
+	}
+	if path == "" {
+		path = "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return path
+}

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -1,0 +1,83 @@
+package discovery
+
+import (
+	"testing"
+
+	"github.com/MB3R-Lab/Bering/internal/connectors/traces"
+	"github.com/MB3R-Lab/Bering/internal/model"
+	"github.com/MB3R-Lab/Bering/internal/schema"
+)
+
+func TestBuild_BasicInference(t *testing.T) {
+	t.Parallel()
+
+	spans := []traces.Span{
+		{
+			TraceID: "t1", SpanID: "1", Service: "frontend", Name: "GET /checkout", Kind: "server",
+			Attributes: map[string]any{"http.request.method": "GET", "http.route": "/checkout"},
+		},
+		{
+			TraceID: "t1", SpanID: "2", ParentSpanID: "1", Service: "checkout", Kind: "server",
+			Attributes: map[string]any{"http.request.method": "POST", "http.route": "/process"},
+		},
+		{
+			TraceID: "t1", SpanID: "3", ParentSpanID: "2", Service: "inventory", Kind: "consumer",
+			Attributes: map[string]any{"messaging.system": "kafka"},
+		},
+	}
+
+	mdl, err := Build(spans, Options{
+		SourceRef:    BuildSourceRef("examples/traces/normalized.sample.json"),
+		DiscoveredAt: "2026-03-03T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	if got, want := len(mdl.Services), 3; got != want {
+		t.Fatalf("services mismatch: got=%d want=%d", got, want)
+	}
+	if got, want := len(mdl.Edges), 2; got != want {
+		t.Fatalf("edges mismatch: got=%d want=%d", got, want)
+	}
+	if got, want := len(mdl.Endpoints), 2; got != want {
+		t.Fatalf("endpoints mismatch: got=%d want=%d", got, want)
+	}
+
+	if mdl.Metadata.Schema.Name != schema.ExpectedSchemaName {
+		t.Fatalf("schema.name mismatch: got=%s", mdl.Metadata.Schema.Name)
+	}
+	if mdl.Metadata.SourceType != SourceTypeBering {
+		t.Fatalf("source_type mismatch: got=%s", mdl.Metadata.SourceType)
+	}
+
+	foundAsync := false
+	for _, edge := range mdl.Edges {
+		if edge.Kind == model.EdgeKindAsync {
+			foundAsync = true
+			if edge.Blocking {
+				t.Fatalf("async edge must be non-blocking: %+v", edge)
+			}
+		}
+	}
+	if !foundAsync {
+		t.Fatalf("expected at least one async edge")
+	}
+}
+
+func TestBuild_UnknownReplicaOverrideFails(t *testing.T) {
+	t.Parallel()
+
+	spans := []traces.Span{
+		{TraceID: "t1", SpanID: "1", Service: "frontend", Name: "GET /health", Kind: "server", Attributes: map[string]any{"http.request.method": "GET", "http.route": "/health"}},
+	}
+
+	_, err := Build(spans, Options{
+		SourceRef:        BuildSourceRef("examples/traces/normalized.sample.json"),
+		DiscoveredAt:     "2026-03-03T00:00:00Z",
+		ReplicasOverride: map[string]int{"unknown": 2},
+	})
+	if err == nil {
+		t.Fatal("expected unknown override service error, got nil")
+	}
+}

--- a/internal/jsoncanon/canonical.go
+++ b/internal/jsoncanon/canonical.go
@@ -1,0 +1,154 @@
+package jsoncanon
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+)
+
+const indent = "  "
+
+// MarshalIndent serializes JSON deterministically by sorting all object keys
+// recursively, including nested map fields.
+func MarshalIndent(v any) ([]byte, error) {
+	doc, err := canonicalize(v)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := writeValue(&buf, doc, 0); err != nil {
+		return nil, err
+	}
+	buf.WriteByte('\n')
+	return buf.Bytes(), nil
+}
+
+func canonicalize(v any) (any, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("marshal value: %w", err)
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+
+	var doc any
+	if err := dec.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("decode canonical json: %w", err)
+	}
+	if dec.More() {
+		return nil, fmt.Errorf("unexpected trailing tokens")
+	}
+	return doc, nil
+}
+
+func writeValue(buf *bytes.Buffer, value any, depth int) error {
+	switch v := value.(type) {
+	case nil:
+		buf.WriteString("null")
+		return nil
+	case bool:
+		if v {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+		return nil
+	case string:
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Errorf("encode string: %w", err)
+		}
+		buf.Write(encoded)
+		return nil
+	case json.Number:
+		if _, err := strconv.ParseFloat(v.String(), 64); err != nil {
+			return fmt.Errorf("invalid json number %q: %w", v.String(), err)
+		}
+		buf.WriteString(v.String())
+		return nil
+	case float64, float32, int, int64, int32, uint, uint64, uint32:
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Errorf("encode number: %w", err)
+		}
+		buf.Write(encoded)
+		return nil
+	case []any:
+		return writeArray(buf, v, depth)
+	case map[string]any:
+		return writeObject(buf, v, depth)
+	default:
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Errorf("encode scalar value: %w", err)
+		}
+		buf.Write(encoded)
+		return nil
+	}
+}
+
+func writeArray(buf *bytes.Buffer, arr []any, depth int) error {
+	if len(arr) == 0 {
+		buf.WriteString("[]")
+		return nil
+	}
+
+	buf.WriteString("[\n")
+	for i, item := range arr {
+		writeIndent(buf, depth+1)
+		if err := writeValue(buf, item, depth+1); err != nil {
+			return err
+		}
+		if i < len(arr)-1 {
+			buf.WriteString(",")
+		}
+		buf.WriteString("\n")
+	}
+	writeIndent(buf, depth)
+	buf.WriteString("]")
+	return nil
+}
+
+func writeObject(buf *bytes.Buffer, obj map[string]any, depth int) error {
+	if len(obj) == 0 {
+		buf.WriteString("{}")
+		return nil
+	}
+
+	keys := make([]string, 0, len(obj))
+	for key := range obj {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	buf.WriteString("{\n")
+	for i, key := range keys {
+		writeIndent(buf, depth+1)
+		encodedKey, err := json.Marshal(key)
+		if err != nil {
+			return fmt.Errorf("encode object key: %w", err)
+		}
+		buf.Write(encodedKey)
+		buf.WriteString(": ")
+		if err := writeValue(buf, obj[key], depth+1); err != nil {
+			return err
+		}
+		if i < len(keys)-1 {
+			buf.WriteString(",")
+		}
+		buf.WriteString("\n")
+	}
+	writeIndent(buf, depth)
+	buf.WriteString("}")
+	return nil
+}
+
+func writeIndent(buf *bytes.Buffer, depth int) {
+	for i := 0; i < depth; i++ {
+		buf.WriteString(indent)
+	}
+}

--- a/internal/jsoncanon/canonical_test.go
+++ b/internal/jsoncanon/canonical_test.go
@@ -1,0 +1,59 @@
+package jsoncanon
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestMarshalIndent_MapInsertionOrderDeterministic(t *testing.T) {
+	t.Parallel()
+
+	first := map[string]any{
+		"metadata": map[string]any{
+			"attributes": map[string]any{
+				"zeta":  1,
+				"alpha": "x",
+			},
+		},
+	}
+
+	second := map[string]any{
+		"metadata": map[string]any{
+			"attributes": map[string]any{
+				"alpha": "x",
+				"zeta":  1,
+			},
+		},
+	}
+
+	rawA, err := MarshalIndent(first)
+	if err != nil {
+		t.Fatalf("marshal first: %v", err)
+	}
+	rawB, err := MarshalIndent(second)
+	if err != nil {
+		t.Fatalf("marshal second: %v", err)
+	}
+
+	if !bytes.Equal(rawA, rawB) {
+		t.Fatalf("canonical output mismatch:\nA=%s\nB=%s", rawA, rawB)
+	}
+}
+
+func TestMarshalIndent_ProducesValidJSON(t *testing.T) {
+	t.Parallel()
+
+	raw, err := MarshalIndent(map[string]any{
+		"b": 2,
+		"a": []any{map[string]any{"z": "v", "a": "w"}},
+	})
+	if err != nil {
+		t.Fatalf("MarshalIndent returned error: %v", err)
+	}
+
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("output must be valid json: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `bering discover` (trace file/dir -> deterministic `bering-model.json`)
- implement `bering validate` (JSON Schema + strict `metadata.schema` checks)
- add dual trace connectors for MVP:
  - normalized spans JSON
  - raw OTel JSON
- add deterministic canonical JSON writer (recursive object key ordering for map safety)
- add examples + docs + integration tests (`discover -> validate`)

## Linked issues
- #6
- #7
- #8
- #9
- #10
- #11
- #12
- #13
- #14

## Repro
```bash
go test ./...

go run ./cmd/bering discover --input examples/traces/normalized.sample.json --out examples/outputs/bering-model.normalized.sample.json --discovered-at 2026-03-03T00:00:00Z
go run ./cmd/bering validate --input examples/outputs/bering-model.normalized.sample.json

go run ./cmd/bering discover --input examples/traces/otel.sample.json --out examples/outputs/bering-model.otel.sample.json --discovered-at 2026-03-03T00:00:00Z
go run ./cmd/bering validate --input examples/outputs/bering-model.otel.sample.json
```

## Notes
- This PR is stacked on top of PR1.
- Bering CI intentionally does not run Sheaft directly (consumer boundary).

